### PR TITLE
fix: remove frappe as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 braintree==3.57.1
-frappe
+# frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro==1.11.0
 googlemaps==3.1.1
 pandas==0.24.2


### PR DESCRIPTION
For Python3.7+ compatibility